### PR TITLE
Remove unneeded reference to datomic mvn repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,6 @@
         <enabled>true</enabled>
       </releases>
     </repository>
-    <repository>
-      <id>datomic-maven</id>
-      <name>Datomic Internal Maven</name>
-      <url>s3://datomic-maven/releases</url>
-    </repository>
   </repositories>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Since I don't have the S3 credentials, the reference to the datomic-maven repo was blowing up for me. I don't  believe we need it anyway.
