### PR TITLE
Get transit-format instead of transit, pass through JVM memory args

### DIFF
--- a/bin/get-transit
+++ b/bin/get-transit
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-cd `dirname $0`/../..
-
-if [ ! -d "transit" ]; then
-  git clone git@github.com:cognitect/transit.git
-else
-  echo "transit exists"
-fi

--- a/bin/get-transit-format
+++ b/bin/get-transit-format
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd `dirname $0`/../..
+
+if [ ! -d "transit-format" ]; then
+  git clone git@github.com:cognitect/transit-format.git
+else
+  echo "transit-format exists"
+fi

--- a/bin/verify
+++ b/bin/verify
@@ -1,10 +1,28 @@
 #!/bin/bash
 
+set -e
+
 cd `dirname $0`/..
 
-ARGS="$@"
+XMS=-Xms1g
+XMX=-Xmx1g
 
-bin/get-transit
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        -Xmx*)
+            XMX=$1
+            ;;
+        -Xms*)
+            XMS=$1
+            ;;
+        *)
+            ARGS="$ARGS $1"
+    esac
+    shift
+done
+
+bin/get-transit-format
 
 if [ -z "$ARGS" ] || [[ $ARGS == *java* ]]; then
   bin/get-transit-java
@@ -26,6 +44,5 @@ if [ -z "$ARGS" ] || [[ $ARGS == *python* ]]; then
   bin/get-transit-python
 fi
 
-
-exec java -server -Xms1g -Xmx1g -cp `bin/classpath`:`pwd`/test clojure.main -m transit.verify "$@"
+exec java -server $XMS $XMX -cp `bin/classpath`:`pwd`/test clojure.main -m transit.verify $ARGS
 


### PR DESCRIPTION
Improvements to bin/verify script
